### PR TITLE
Handle direct SQS payloads in notifier

### DIFF
--- a/apps/backend/src/main/java/com/example/Tucasdesk/service/NotifierService.java
+++ b/apps/backend/src/main/java/com/example/Tucasdesk/service/NotifierService.java
@@ -37,8 +37,10 @@ public class NotifierService {
         log.info("Received SQS message: {}", messageJson);
         try {
             JsonNode rootNode = objectMapper.readTree(messageJson);
-            String eventPayloadString = rootNode.path("Message").asText();
-            JsonNode eventPayload = objectMapper.readTree(eventPayloadString);
+            JsonNode messageNode = rootNode.get("Message");
+            JsonNode eventPayload = (messageNode != null && messageNode.isTextual() && StringUtils.hasText(messageNode.asText()))
+                    ? objectMapper.readTree(messageNode.asText())
+                    : rootNode;
 
             String eventType = eventPayload.path("eventType").asText("UNKNOWN");
             int ticketId = eventPayload.path("chamadoId").asInt();

--- a/apps/backend/src/test/java/com/example/Tucasdesk/service/NotifierServiceTest.java
+++ b/apps/backend/src/test/java/com/example/Tucasdesk/service/NotifierServiceTest.java
@@ -58,6 +58,23 @@ public class NotifierServiceTest {
     }
 
     @Test
+    void receiveMessage_shouldHandleDirectSqsPayload() {
+        // Arrange
+        String directSqsMessage = "{\"eventType\":\"TICKET_UPDATED\",\"chamadoId\":321}";
+
+        when(awsSesProperties.isEnabled()).thenReturn(true);
+        when(awsSesProperties.getFromAddress()).thenReturn("sender@example.com");
+        when(awsSesProperties.getToAddresses()).thenReturn(List.of("recipient@example.com"));
+        when(sesV2ClientProvider.getIfAvailable()).thenReturn(sesV2Client);
+
+        // Act
+        notifierService.receiveMessage(directSqsMessage);
+
+        // Assert
+        verify(sesV2Client, times(1)).sendEmail(any(SendEmailRequest.class));
+    }
+
+    @Test
     void receiveMessage_shouldDoNothing_whenSesIsDisabled() {
         // Arrange
         String snsMessage = "{\"Message\":\"{}\"}";


### PR DESCRIPTION
## Summary
- allow `NotifierService` to process direct SQS payloads when SNS wrapping is absent
- add test coverage ensuring direct queue messages still trigger email notifications

## Testing
- mvn test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286a328e788327951391608b52d407)